### PR TITLE
Constructor bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@
  * */
 function CloudinaryStorage (opts) {
   if(opts && opts.cloudinary){
-    this.cloudinary = opts.cloudinary;
+    // Checking to see if opts.cloudinary.cloudinary is present for backwards compatibility
+    // even though opts.cloudinary is the correct way to pass.
+    this.cloudinary = opts.cloudinary.cloudinary ? opts.cloudinary.cloudinary : opts.cloudinary;
   }else{
     throw new Error('Expected opts.cloudinary to be a configured cloudinary object.');
   }

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@
  * A simple storage engine
  * */
 function CloudinaryStorage (opts) {
-  if(opts && opts.cloudinary && opts.cloudinary.cloudinary){
-    this.cloudinary = opts.cloudinary.cloudinary;
+  if(opts && opts.cloudinary){
+    this.cloudinary = opts.cloudinary;
   }else{
     throw new Error('Expected opts.cloudinary to be a configured cloudinary object.');
   }


### PR DESCRIPTION
The constructor had a bug where it was checking `opts.cloudinary.cloudinary` when it should only be checking `opts.cloudinary`. Also making it backwards compatible in case some figured out the problem and altered the construction call passing `{ cloudinary: { cloudinary: Cloudinary } }` instead of just `{ cloudinary: Cloudinary }`.